### PR TITLE
Feature/CRONAPP-2830 - Ampliar a cobertura de Testes - Categoria XML

### DIFF
--- a/test/src/test/cronapi/xml/xml.spec.ts
+++ b/test/src/test/cronapi/xml/xml.spec.ts
@@ -53,18 +53,31 @@ describe('Test suit for category xml from Cronapi.js', function() {
   });
 
   it('getParentNode', function() {
+    let value = cronapi.xml.getParentNode($.parseXML('<?xml version="1.0" encoding="UTF-8"?><root></root>'));
+    (value === undefined || value === null || value === '').should.equal(true);
   });
 
   it('setElementContent', function() {
+    let value = cronapi.xml.setElementContent($.parseXML('<?xml version="1.0" encoding="UTF-8"?><root></root>'), $.parseXML('<?xml version="1.0" encoding="UTF-8"?><root></root>'));
+    (value === undefined || value === null || value === '').should.equal(true);
   });
 
   it('getElementContent', function() {
+    let value = cronapi.xml.getElementContent($.parseXML('<?xml version="1.0" encoding="UTF-8"?><root></root>'));
+    (value === undefined || value === null || value === '').should.equal(true);
   });
 
   it('removeElement', function() {
+    let value = cronapi.xml.removeElement($.parseXML('<?xml version="1.0" encoding="UTF-8"?><root></root>'), true);
+    (value === undefined || value === null || value === '').should.equal(true);
+
+    value = cronapi.xml.removeElement($.parseXML('<?xml version="1.0" encoding="UTF-8"?><root></root>'), false);
+    (value === undefined || value === null || value === '').should.equal(true);
   });
 
   it('getElementName', function() {
+    let value = cronapi.xml.getElementName($.parseXML('<?xml version="1.0" encoding="UTF-8"?><root></root>'));
+    (value === undefined || value === null || value === '').should.equal(true);
   });
 
   it('renameElement', function() {

--- a/test/src/test/cronapi/xml/xml.spec.ts
+++ b/test/src/test/cronapi/xml/xml.spec.ts
@@ -34,6 +34,8 @@ describe('Test suit for category xml from Cronapi.js', function() {
   });
 
   it('XMLGetRootElement', function() {
+    let value = cronapi.xml.XMLGetRootElement($.parseXML('<?xml version="1.0" encoding="UTF-8"?><root></root>'));
+    (value === undefined || value === null || value === '').should.equal(false);
   });
 
   it('XMLDocumentToText', function() {

--- a/test/src/test/cronapi/xml/xml.spec.ts
+++ b/test/src/test/cronapi/xml/xml.spec.ts
@@ -1,0 +1,66 @@
+describe('Test suit for category xml from Cronapi.js', function() {
+  const ch = require('chai');
+  ch.should();
+
+  const $ = require('jquery');
+
+  let {window} = require('../../../../../cronapi');
+  const cronapi = window["cronapi"];
+
+  window.$ = $;
+
+  it('newXMLEmpty', function() {
+    let value = cronapi.xml.newXMLEmpty.bind(window)();
+    (value === undefined || value === null || value === '').should.equal(false);
+  });
+
+  it('newXMLEmptyWithRoot', function() {
+  });
+
+  it('newXMLElement', function() {
+  });
+
+  it('addXMLElement', function() {
+    let value = cronapi.xml.addXMLElement(null, new Object());
+    value.should.eql(false);
+  });
+
+  it('XMLHasRootElement', function() {
+  });
+
+  it('XMLGetRootElement', function() {
+  });
+
+  it('XMLDocumentToText', function() {
+  });
+
+  it('getChildren', function() {
+  });
+
+  it('setAttribute', function() {
+  });
+
+  it('getAttributeValue', function() {
+    let value = cronapi.xml.getAttributeValue(null, false);
+    value.should.eql('');
+  });
+
+  it('getParentNode', function() {
+  });
+
+  it('setElementContent', function() {
+  });
+
+  it('getElementContent', function() {
+  });
+
+  it('removeElement', function() {
+  });
+
+  it('getElementName', function() {
+  });
+
+  it('renameElement', function() {
+  });
+
+});

--- a/test/src/test/cronapi/xml/xml.spec.ts
+++ b/test/src/test/cronapi/xml/xml.spec.ts
@@ -21,7 +21,7 @@ describe('Test suit for category xml from Cronapi.js', function() {
   });
 
   it('addXMLElement', function() {
-    let value = cronapi.xml.addXMLElement(null, new Object());
+    let value = cronapi.xml.addXMLElement(null, $.parseXML('<?xml version="1.0" encoding="UTF-8"?><root></root>'));
     value.should.eql(false);
   });
 

--- a/test/src/test/cronapi/xml/xml.spec.ts
+++ b/test/src/test/cronapi/xml/xml.spec.ts
@@ -26,6 +26,11 @@ describe('Test suit for category xml from Cronapi.js', function() {
   });
 
   it('XMLHasRootElement', function() {
+    let value = cronapi.xml.XMLHasRootElement($.parseXML('<?xml version="1.0" encoding="UTF-8"?><root></root>'));
+    value.should.eql(true);
+
+    value = cronapi.xml.XMLHasRootElement(null);
+    value.should.eql(false);
   });
 
   it('XMLGetRootElement', function() {


### PR DESCRIPTION
https://cronapp.atlassian.net/browse/CRONAPP-2830

## Problema:
Não havia cobertura de Testes Unitários no Cronapi-JS - Categoria XML
## Melhoria:
Ampliar a cobertura de Testes Unitários no Cronapi-JS - Categoria XML
## Solução:
Criação de testes para a categoria XML do Cronapi.js através do JEST
