### PR TITLE
CRONAPP-3424 Bloco "Focar componente" apresenta erro no console e não…

### DIFF
--- a/cronapi.js
+++ b/cronapi.js
@@ -1928,7 +1928,7 @@ function cronapi() {
    */
   this.cronapi.screen.focusComponent = function(/** @type {ObjectType.OBJECT} @blockType ids_from_screen*/ id) {
     this.cronapi.$scope.safeApply( function() {
-      if( tinyMCE && tinyMCE.get(id) !== undefined) {
+      if(tinyMCE && tinyMCE.get(id)) {
         tinyMCE.get(id).focus();
       }else{
         $('#'+id).find('*').addBack().focus();


### PR DESCRIPTION
Solução: Verificar corretamente se o componente é um tinyMCE