### PR TITLE
CRONAPP-3350  Atualizar a release para 2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cronapi-js",
-  "version": "2.7.6",
+  "version": "2.9.0",
   "description": "Public library for CronApp's users",
   "main": "cronapi.js",
   "scripts": {


### PR DESCRIPTION
Solução:
Atualização do npm para 2.9.0 (sem publicação no npm)